### PR TITLE
chore: do not specify minor version of Dockerfile syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.4
+#syntax=docker/dockerfile:1
 
 # Versions
 FROM dunglas/frankenphp:1-php8.3 AS frankenphp_upstream


### PR DESCRIPTION
> We recommend using docker/dockerfile:1, which
> always points to the latest stable release of the
> version 1 syntax, and receives both "minor" and
> "patch" updates for the version 1 release cycle.

https://docs.docker.com/build/buildkit/frontend/